### PR TITLE
fix sockjs 404 error

### DIFF
--- a/app/public/sockjs/info
+++ b/app/public/sockjs/info
@@ -1,0 +1,1 @@
+{"websocket": false}


### PR DESCRIPTION
This fixes the sockjs 404 error that appears in the js console of https://registrar.ens.domains/:

```
Failed to load resource: the server responded with a status of 404 ()           /sockjs/info?cb=z_0yiowp11
```