### PR TITLE
Avoid trying to access beyond end of knownNames array

### DIFF
--- a/app/imports/templates/components/newBid.js
+++ b/app/imports/templates/components/newBid.js
@@ -7,7 +7,7 @@ Template['components_newBid'].onRendered(function() {
   template = this;
   let name = Session.get('searched');
   TemplateVar.set(template, 'anonymizer', 0.5);
-  let launchRatio = (Date.now()/1000 - registrar.registryStarted.toFixed())/(8*7*24*60*60);
+  let launchRatio = Math.min((Date.now()/1000 - registrar.registryStarted.toFixed())/(8*7*24*60*60), 1);
   console.log('launchRatio', launchRatio);
   TemplateVar.set(template, 'bidAmount', 0.01);
   TemplateVar.set(template, 'depositAmount', 0);


### PR DESCRIPTION
I was seeing the following exception in the console when in a state where I'd submitted a bid, but the auction wasn't open:

```
51ec55b8ddb3549fcf31dec0c746493c9aa2b734.js:3 Exception from Tracker afterFlush function:
51ec55b8ddb3549fcf31dec0c746493c9aa2b734.js:3 TypeError: Cannot read property 'length' of undefined
    at h.TemplateInstance.l.randomName (51ec55b8ddb3549fcf31dec0c746493c9aa2b734.js:207)
    at h.TemplateInstance.l.randomName (51ec55b8ddb3549fcf31dec0c746493c9aa2b734.js:207)
    at h.TemplateInstance.l.createHashesArray (51ec55b8ddb3549fcf31dec0c746493c9aa2b734.js:207)
    at h.TemplateInstance.<anonymous> (51ec55b8ddb3549fcf31dec0c746493c9aa2b734.js:207)
    at 51ec55b8ddb3549fcf31dec0c746493c9aa2b734.js:107
    at Function.e._withTemplateInstanceFunc (51ec55b8ddb3549fcf31dec0c746493c9aa2b734.js:107)
    at n (51ec55b8ddb3549fcf31dec0c746493c9aa2b734.js:107)
    at h.View.<anonymous> (51ec55b8ddb3549fcf31dec0c746493c9aa2b734.js:107)
    at 51ec55b8ddb3549fcf31dec0c746493c9aa2b734.js:106
    at Object.h._withCurrentView (51ec55b8ddb3549fcf31dec0c746493c9aa2b734.js:106)
```

This commit should fix that by preventing launchRatio going above 1 (it currently works out at over 3) and therefore avoid trying to access beyond the end of the knownNames array when picking a random name.